### PR TITLE
存在しないRepLinkに接続時、例外を発生させない

### DIFF
--- a/circle_core/constants.py
+++ b/circle_core/constants.py
@@ -82,3 +82,4 @@ class WebsocketStatusCode(enum.Enum):
     DATA_CANNOT_ACCEPT = 1003
     VIOLATE_POLICY = 1008
     MESSAGE_IS_TOO_BIG = 1009
+    NOT_FOUND = 4000

--- a/circle_core/workers/http/replication_master.py
+++ b/circle_core/workers/http/replication_master.py
@@ -67,12 +67,15 @@ class ReplicationMaster(WebSocketHandler):
 
     def open(self, link_uuid):
         """他のCircleCoreから接続された際に呼ばれる."""
-        logger.debug('Connected to another CircleCore')
+        logger.debug('Connected from another CircleCore')
         self.link_uuid = link_uuid
         self.replication_link = ReplicationLink.query.get(link_uuid)
 
         if not self.replication_link:
-            raise HTTPError(404)
+            logger.warning('ReplicationLink {} was not found. Connection close.')
+            self.close(code=WebsocketStatusCode.NOT_FOUND.value,
+                       reason='ReplicationLink {} was not found.'.format(link_uuid))
+            return
 
         self.state = ReplicationState.HANDSHAKING
         self.sync_states = ImmutableDict(


### PR DESCRIPTION
[WSで404でつながれたときに例外が投げられる](https://www.pivotaltracker.com/story/show/140742423)
- Master側
    - Not Found Codeを設定してConnection Closeする
        - [4000番台がApp用](https://developer.mozilla.org/ja/docs/Web/API/CloseEvent)
- Slave側
    - 変更なし
        - エラーコードが通知されている場合は、エラーを記録して終了する。復活するには再起動させる。