### PR TITLE
TimedDB更新時に既存のデータを上書きしてしまう問題修正

### DIFF
--- a/circle_core/database.py
+++ b/circle_core/database.py
@@ -420,7 +420,7 @@ class QueuedWriter(object):
                 if timestamp >= last_timestamp:
                     break
             if idx:
-                updates, self.updates = self.updates[:idx - 1], self.updates[idx - 1:]
+                updates, self.updates = self.updates[:idx], self.updates[idx:]
                 self.time_db_bundle.update(updates)
 
         # remove timeout and reset


### PR DESCRIPTION
resolve #130 

### 原因
- `whisper.update_many` は同じtimestampに対する書き込みは加算ではなく上書きしている
- 1秒以内に複数回の受信がある場合、 `TimedDBBundle.update` は同じtimestampに対して書き込みを行う可能性がある
- masterとslaveは `TimedDBBundle.update` のタイミングが異なる為、結果異なるグラフが生成される

### 解決
- update前にfetchして、各々加算した上でupdateする