### PR TITLE
依存関係の更新と、それによるテスト失敗の修正

### DIFF
--- a/circle_core/database.py
+++ b/circle_core/database.py
@@ -135,7 +135,11 @@ class Database(object):
         if not isinstance(box_or_uuid, uuid.UUID):
             box_or_uuid = box_or_uuid.uuid
 
-        return 'message_box_' + b58encode(box_or_uuid.bytes)
+        encoded = b58encode(box_or_uuid.bytes)
+        if isinstance(encoded, bytes):
+            encoded = encoded.decode('latin1')
+
+        return 'message_box_{}'.format(encoded)
 
     def find_table_for_message_box(self, message_box, create_if_not_exists=True):
         """MessageBox Tableを取得する.

--- a/circle_core/helpers/nanomsg.py
+++ b/circle_core/helpers/nanomsg.py
@@ -83,7 +83,7 @@ class Receiver(object):
                 topic, message = plain_msg[:TOPIC_LENGTH], plain_msg[TOPIC_LENGTH:]
                 message = json.loads(message)
                 callback(topic, message)
-            except:
+            except Exception:
                 import traceback
                 traceback.print_exc()
 

--- a/circle_core/workers/http/replication_master.py
+++ b/circle_core/workers/http/replication_master.py
@@ -19,7 +19,6 @@ Note right of S: when Slave's circle core info is updated
 S->M: "circle_core_updated" cmd
 ```
 
-
 """
 import enum
 import json
@@ -28,7 +27,6 @@ import threading
 import uuid
 
 from click import get_current_context
-
 from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.web import HTTPError

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,13 @@ install_requires = [
     'Flask>=0.11',
     'Flask-OAuthlib',
     'mysql-connector-python-rf',
-    'nnpy',
+    'nnpy==1.4.2',
     'python-dateutil',
     'six',
     'sqlalchemy>=1.1.4',
     'tornado',
     'websocket-client',
-    'whisper==0.10.0rc1',
+    'whisper==1.1.2',
 ]
 if PY2:
     install_requires.append('enum34')
@@ -33,8 +33,8 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=install_requires,
     dependency_links=[
-        'git+https://github.com/nanomsg/nnpy.git#egg=nnpy',
-        'git+https://github.com/graphite-project/whisper.git@b783ab3f577f3f60db607adda241e29b7242bcf4#egg=whisper-0.10.0rc1',
+        # 'git+https://github.com/nanomsg/nnpy.git#egg=nnpy',
+        # 'git+https://github.com/graphite-project/whisper.git@b783ab3f577f3f60db607adda241e29b7242bcf4#egg=whisper-0.10.0rc1',
     ],
     entry_points={
         'console_scripts': [
@@ -46,7 +46,6 @@ setup(
             'coverage',
             'flake8',
             'flake8-import-order',
-            'nnpy',
             'pytest',
             'pytest-timeout',
             'tcptest',

--- a/tests/models/test_cc_info.py
+++ b/tests/models/test_cc_info.py
@@ -2,7 +2,6 @@
 import pytest
 
 from circle_core.models import CcInfo, MetaDataSession
-
 from .utils import setup_db
 
 

--- a/tests/models/test_invitation.py
+++ b/tests/models/test_invitation.py
@@ -2,7 +2,6 @@
 import pytest
 
 from circle_core.models import generate_uuid, Invitation, MetaDataSession
-
 from .utils import setup_db
 
 

--- a/tests/models/test_message_box.py
+++ b/tests/models/test_message_box.py
@@ -4,7 +4,6 @@ import uuid
 import pytest
 
 from circle_core.models import generate_uuid, MessageBox, MetaDataSession, Module, Schema
-
 from .utils import setup_db
 
 

--- a/tests/models/test_module.py
+++ b/tests/models/test_module.py
@@ -3,7 +3,6 @@ import pytest
 
 from circle_core.models import generate_uuid, MessageBox, MetaDataSession, Module, Schema
 from circle_core.models.module import ModuleAttribute, ModuleAttributes
-
 from .utils import setup_db
 
 

--- a/tests/models/test_replication_link.py
+++ b/tests/models/test_replication_link.py
@@ -2,7 +2,6 @@
 import pytest
 
 from circle_core.models import generate_uuid, MessageBox, MetaDataSession, Module, ReplicationLink, Schema
-
 from .utils import setup_db
 
 

--- a/tests/models/test_schema.py
+++ b/tests/models/test_schema.py
@@ -3,7 +3,6 @@ import pytest
 
 from circle_core.models import generate_uuid, MessageBox, MetaDataSession, Module, Schema, SchemaProperties
 from circle_core.models.schema import SchemaProperty
-
 from .utils import setup_db
 
 

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -2,7 +2,6 @@
 import pytest
 
 from circle_core.models import MetaDataSession, User
-
 from .utils import setup_db
 
 

--- a/tests/workers/test_replication.py
+++ b/tests/workers/test_replication.py
@@ -98,7 +98,7 @@ skip_build = on
         module_uuid
     ], check=True, stdout=subprocess.PIPE)
     box_uuid = re.search(r'^MessageBox "([0-9A-Fa-f-]+)" is added\.$', result.stdout.decode(), re.MULTILINE).group(1)
-    table_name = 'message_box_{}'.format(b58encode(UUID(box_uuid).bytes))
+    table_name = 'message_box_{}'.format(b58encode(UUID(box_uuid).bytes).decode('latin1'))
 
     result = subprocess.run(
         ['crcr', 'replication_link', 'add', '--name', 'slave1', '--all-boxes'],

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,6 @@
 envlist = py35,flake8,sphinx
 
 [testenv]
-deps =
-  https://github.com/nanomsg/nnpy/tarball/master
-  https://github.com/graphite-project/whisper/tarball/b783ab3f577f3f60db607adda241e29b7242bcf4
 setenv =
   LIBRARY_PATH=/usr/local/lib
   PYTHONDONTWRITEBYTECODE = 1


### PR DESCRIPTION
nnpy, whisperのバージョンを指定した。（TODO: 今後最新バージョンに追随する & py3.7まで対応すること）

base58最新版でb58encode()がbytesを返すように変わっていたので、それに対応した。type hinting待ったなし