### PR TITLE
トークン切れ時にログイン画面に戻らない問題修正

### DIFF
--- a/circle_core/web/src/js/main.jsx
+++ b/circle_core/web/src/js/main.jsx
@@ -13,7 +13,7 @@ import muiTheme from './muiTheme'
 
 const history = createBrowserHistory()
 const initialState = {}
-const store = configureStore(history, initialState)
+export const store = configureStore(history, initialState)
 store.runSaga(rootSaga)
 
 

--- a/circle_core/web/src/js/reducers/auth.js
+++ b/circle_core/web/src/js/reducers/auth.js
@@ -9,7 +9,6 @@ oauthToken.load()
 
 const initialState = {
   token: oauthToken,
-  tokenLoaded: false,
   tokenIsValid: oauthToken.isValid(),
 }
 const entities = handleActions({


### PR DESCRIPTION
#150 対応時、 外部で `require` している `store` の `export` を外してしまったため、 redux action が発行されない状態になっていた。再度 `export` するように修正。